### PR TITLE
use flup-py3 1.0.3 instead of github version

### DIFF
--- a/example/python3/requirements.txt
+++ b/example/python3/requirements.txt
@@ -3,6 +3,4 @@
 # in gofast example
 #
 
-#flup-py3
-#hg+https://hg.saddi.com/flup-py3.0/#egg=flup-py3
-git+https://github.com/pquentin/flup-py3.git
+flup-py3>=1.0.3


### PR DESCRIPTION
Thanks to @asaddi, @pquentin and @agushuley, the flup-py3 can now be properly used in Python 3.4+ and the requirements.txt can be simplified

Refrence: https://github.com/pquentin/flup-py3/pull/3#issuecomment-364236224