### PR TITLE
bugfix: can not get schema from http.Request.URL 

### DIFF
--- a/session.go
+++ b/session.go
@@ -119,7 +119,7 @@ func BasicParamsMap(inner SessionHandler) SessionHandler {
 		req.Params["REMOTE_ADDR"] = remoteAddr
 		req.Params["REMOTE_PORT"] = remotePort
 		req.Params["SERVER_PORT"] = serverPort
-		req.Params["SERVER_NAME"] = r.Host
+		req.Params["SERVER_NAME"] = host
 		req.Params["SERVER_PROTOCOL"] = r.Proto
 		req.Params["SERVER_SOFTWARE"] = "gofast"
 		req.Params["REDIRECT_STATUS"] = "200"

--- a/session.go
+++ b/session.go
@@ -97,15 +97,15 @@ func BasicParamsMap(inner SessionHandler) SessionHandler {
 
 		r := req.Raw
 
-		var isHTTPS string
-		if r.URL.Scheme == "https" || r.URL.Scheme == "wss" {
-			isHTTPS = "on"
+		isHTTPS := r.TLS != nil
+		if isHTTPS {
+			req.Params["HTTPS"] = "on"
 		}
 
 		remoteAddr, remotePort, _ := net.SplitHostPort(r.RemoteAddr)
-		_, serverPort, err := net.SplitHostPort(r.URL.Host)
+		host, serverPort, err := net.SplitHostPort(r.Host)
 		if err != nil {
-			if r.URL.Scheme == "https" || r.URL.Scheme == "wss" {
+			if isHTTPS {
 				serverPort = "443"
 			} else {
 				serverPort = "80"
@@ -115,7 +115,6 @@ func BasicParamsMap(inner SessionHandler) SessionHandler {
 		// the basic information here
 		req.Params["CONTENT_TYPE"] = r.Header.Get("Content-Type")
 		req.Params["CONTENT_LENGTH"] = r.Header.Get("Content-Length")
-		req.Params["HTTPS"] = isHTTPS
 		req.Params["GATEWAY_INTERFACE"] = "CGI/1.1"
 		req.Params["REMOTE_ADDR"] = remoteAddr
 		req.Params["REMOTE_PORT"] = remotePort


### PR DESCRIPTION
can not get request schema from http.Request.URL，because

[Request doc](https://golang.org/pkg/net/http/#Request)

    // For server requests the URL is parsed from the URI
    // supplied on the Request-Line as stored in RequestURI.  For
    // most requests, fields other than Path and RawQuery will be
    // empty. (See RFC 2616, Section 5.1.2)
    URL *url.URL