### PR TITLE
Improve parameters mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,80 @@ func main() {
 </details>
 
 
+#### Customizing Request Session with Middleware
+
+Each web server request will result in a [gofast.Request][gofast-request].
+And each [gofast.Request][gofast-request] will first run through SessionHandler
+before handing to the `Do()` method of [gofast.Client][gofast-client].
+
+The default [gofast.BasicSession][gofast-basicsession] implementation does
+nothing. The library function like [gofast.NewPHPFS][gofast-phpfs],
+[gofast.NewFileEndpoint][gofast-file-endpoint] are [gofast.Middleware][gofast-middleware]
+implementations, which are lower level middleware chains.
+
+So you may customize your own session by implemention [gofast.Middleware][gofast-middleware].
+
+```go
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/yookoala/gofast"
+)
+
+func main() {
+	// Get fastcgi application server tcp address
+	// from env FASTCGI_ADDR. Then configure
+	// connection factory for the address.
+	address := os.Getenv("FASTCGI_ADDR")
+	connFactory := gofast.SimpleConnFactory("tcp", address)
+
+	// a custom authentication handler
+	customAuth := func(inner gofast.SessionHandler) gofast.SessionHandler {
+		return func(client gofast.Client, req *gofast.Request) (gofast.ResponsePipe, error) {
+			user, err := someCustomAuth(
+				req.Raw.Header.Get("Authorization"))
+			if err != nil {
+				// if login not success
+				return nil, err
+			}
+			// set REMOTE_USER accordingly
+			req.Params["REMOTE_USER"] = user
+			// run inner session handler
+			return inner(client, req)
+		}
+	}
+
+	// session handler
+	sess := gofast.Chain(
+		customAuth,            // maps REMOTE_USER
+		gofast.BasicParamsMap, // maps common CGI parameters
+		gofast.MapHeader,      // maps header fields into HTTP_* parameters
+		gofast.MapRemoteHost,  // maps REMOTE_HOST
+	)(gofast.BasicSession)
+
+	// route all requests to a single php file
+	http.Handle("/", gofast.NewHandler(
+		gofast.NewFileEndpoint("/var/www/html/index.php")(sess),
+		gofast.SimpleClientFactory(connFactory, 0),
+	))
+
+	// serve at 8080 port
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+```
+
+[gofast-basicsession]: https://godoc.org/github.com/yookoala/gofast#BasicSession
+[gofast-request]: https://godoc.org/github.com/yookoala/gofast#Request
+[gofast-client]: https://godoc.org/github.com/yookoala/gofast#Client
+[gofast-phpfs]: https://godoc.org/github.com/yookoala/gofast#NewPHPFS
+[gofast-file-endpoint]: https://godoc.org/github.com/yookoala/gofast#NewFileEndpoint
+[gofast-middleware]: https://godoc.org/github.com/yookoala/gofast#Middleware
 
 #### Pooling Clients
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ func main() {
 
 	// route all requests to relevant PHP file
 	http.Handle("/", gofast.NewHandler(
-		gofast.NewPHPFS("/var/www/html"),
+		gofast.NewPHPFS("/var/www/html")(gofast.BasicSession),
 		gofast.SimpleClientFactory(connFactory, 0),
 	))
 
@@ -192,7 +192,7 @@ func main() {
 		30*time.Second, // life span of a client before expire
 	)
 	http.Handle("/", gofast.NewHandler(
-		gofast.NewPHPFS("/v/var/www/htmlar/www/html"),
+		gofast.NewPHPFS("/var/www/html")(gofast.BasicSession),
 		pool.CreateClient,
 	))
 

--- a/client.go
+++ b/client.go
@@ -558,3 +558,18 @@ func (pipes *ResponsePipe) writeResponse(w http.ResponseWriter) (err error) {
 	}
 	return
 }
+
+// ClientFunc is a function wrapper of a Client interface
+// shortcut implementation. Mainly for testing and development
+// purpose.
+type ClientFunc func(req *Request) (resp *ResponsePipe, err error)
+
+// Do implements Client.Do
+func (c ClientFunc) Do(req *Request) (resp *ResponsePipe, err error) {
+	return c(req)
+}
+
+// Close implements Client.Close
+func (c ClientFunc) Close() error {
+	return nil
+}

--- a/session.go
+++ b/session.go
@@ -225,7 +225,7 @@ func (fs *FileSystemRouter) Router() Middleware {
 //
 // It is a convention to map header field SomeRandomField to
 // HTTP_SOME_RANDOM_FIELD. For example, if a header field "X-Hello-World" is in
-// the header, it will be mapped as "X_HELLO_WORLD" in the fastcgi parameter
+// the header, it will be mapped as "HTTP_X_HELLO_WORLD" in the fastcgi parameter
 // field.
 //
 // Note: HTTP_CONTENT_TYPE and HTTP_CONTENT_LENGTH cannot be overridden.

--- a/session.go
+++ b/session.go
@@ -54,7 +54,11 @@ type SessionHandler func(client Client, req *Request) (resp *ResponsePipe, err e
 //
 type Middleware func(SessionHandler) SessionHandler
 
-// Chain chains middlewares into a single middleware
+// Chain chains middlewares into a single middleware.
+//
+// The middlewares will be chained from outer to inner. The first
+// middleware will be the first to handle Client and Request. It
+// is also the last to handle ResponsePipe and error.
 func Chain(middlewares ...Middleware) Middleware {
 	if len(middlewares) == 0 {
 		return nil

--- a/session.go
+++ b/session.go
@@ -89,6 +89,7 @@ func BasicSession(client Client, req *Request) (*ResponsePipe, error) {
 //  SERVER_SOFTWARE
 //  REDIRECT_STATUS
 //  REQUEST_METHOD
+//  REQUEST_SCHEME
 //  REQUEST_URI
 //  QUERY_STRING
 //
@@ -123,6 +124,7 @@ func BasicParamsMap(inner SessionHandler) SessionHandler {
 		req.Params["SERVER_PROTOCOL"] = r.Proto
 		req.Params["SERVER_SOFTWARE"] = "gofast"
 		req.Params["REDIRECT_STATUS"] = "200"
+		req.Params["REQUEST_SCHEME"] = r.URL.Scheme
 		req.Params["REQUEST_METHOD"] = r.Method
 		req.Params["REQUEST_URI"] = r.RequestURI
 		req.Params["QUERY_STRING"] = r.URL.RawQuery

--- a/session.go
+++ b/session.go
@@ -133,6 +133,20 @@ func BasicParamsMap(inner SessionHandler) SessionHandler {
 	}
 }
 
+// MapRemoteHost does reverse DNS lookup on the r.RemoteAddr IP
+// address.
+func MapRemoteHost(inner SessionHandler) SessionHandler {
+	return func(client Client, req *Request) (*ResponsePipe, error) {
+		r := req.Raw
+		remoteAddr, _, _ := net.SplitHostPort(r.RemoteAddr)
+		names, _ := net.LookupAddr(remoteAddr)
+		if len(names) > 0 {
+			req.Params["REMOTE_HOST"] = strings.TrimRight(names[0], ".")
+		}
+		return inner(client, req)
+	}
+}
+
 // FilterAuthReqParams filter out FCGI_PARAMS key-value that is explicitly
 // forbidden to passed on in factcgi specification, include:
 //  CONTENT_LENGTH;

--- a/session_test.go
+++ b/session_test.go
@@ -92,28 +92,6 @@ func (vfs VFS) Open(name string) (f http.File, err error) {
 	return
 }
 
-func NopClient(id uint16) gofast.Client {
-	return nopClient(id)
-}
-
-type nopClient uint16
-
-func (nopClient) Do(req *gofast.Request) (resp *gofast.ResponsePipe, err error) {
-	return
-}
-
-func (nc nopClient) AllocID() uint16 {
-	return uint16(nc)
-}
-
-func (nopClient) ReleaseID(uint16) {
-
-}
-
-func (nopClient) Close() error {
-	return nil
-}
-
 func TestMapFilterRequest(t *testing.T) {
 
 	dummyModTime := time.Now().Add(-10 * time.Second)
@@ -169,7 +147,9 @@ func TestMapFilterRequest(t *testing.T) {
 		t.Errorf("unexpected error: %s", err)
 		return
 	}
-	c := NopClient(1)
+	c := gofast.ClientFunc(func(req *gofast.Request) (resp *gofast.ResponsePipe, err error) {
+		return
+	})
 	_, err = sess(c, gofast.NewRequest(r))
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)


### PR DESCRIPTION
* add `REQUEST_SCHEME`.
* add `REMOTE_HOST` as new middleware, with example.
* add `REMOTE_USER` implementation example in README.md.

Fix #27.