### PR TITLE
Set default host when host cannot be split properly

### DIFF
--- a/session.go
+++ b/session.go
@@ -110,6 +110,7 @@ func BasicParamsMap(inner SessionHandler) SessionHandler {
 		remoteAddr, remotePort, _ := net.SplitHostPort(r.RemoteAddr)
 		host, serverPort, err := net.SplitHostPort(r.Host)
 		if err != nil {
+			host = r.Host
 			if isHTTPS {
 				serverPort = "443"
 			} else {


### PR DESCRIPTION
When the Request `Host` does not have a port, e.g. `domain.com` the `SERVER_NAME` will become an empty string.

Instead of doing this, it's better to just take the `Host` and pass it along.

@yookoala What do you think about this? I'm not 100% sure. 