### PR TITLE
Introduce IdPool interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -298,11 +298,16 @@ func (c *client) Do(req *Request) (resp *ResponsePipe, err error) {
 // If the inner connection has been closed before,
 // this method would do nothing and return nil
 func (c *client) Close() error {
+	err := c.ids.Close()
+	if err != nil {
+		return err
+	}
+
 	if c.conn == nil {
 		return nil
 	}
 
-	err := c.conn.Close()
+	err = c.conn.Close()
 	c.conn = nil
 
 	return err

--- a/client.go
+++ b/client.go
@@ -298,16 +298,11 @@ func (c *client) Do(req *Request) (resp *ResponsePipe, err error) {
 // If the inner connection has been closed before,
 // this method would do nothing and return nil
 func (c *client) Close() error {
-	err := c.ids.Close()
-	if err != nil {
-		return err
-	}
-
 	if c.conn == nil {
 		return nil
 	}
 
-	err = c.conn.Close()
+	err := c.conn.Close()
 	c.conn = nil
 
 	return err

--- a/client.go
+++ b/client.go
@@ -353,7 +353,7 @@ type ClientFactory func() (Client, error)
 // available for 16bit request id (65536).
 // Default 0.
 //
-func SimpleClientFactory(connFactory ConnFactory, limit uint32) ClientFactory {
+func SimpleClientFactory(connFactory ConnFactory, limit uint16) ClientFactory {
 	return SimpleClientFactoryWithIdPool(connFactory, NewDynamicIdPool(limit))
 }
 

--- a/client_internal_test.go
+++ b/client_internal_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestIDPool_Alloc(t *testing.T) {
 	t.Logf("default limit: %d", 65535)
-	ids := newIDs(0)
+	ids := NewDynamicIdPool(0)
 	for i := uint32(0); i <= 65535; i++ {
 		if want, have := uint16(i), ids.Alloc(); want != have {
 			t.Errorf("expected %d, got %d", want, have)
@@ -18,7 +18,7 @@ func TestIDPool_Alloc(t *testing.T) {
 	// test if new id can be allocated
 	// when all ids are already allocated
 	newAlloc := make(chan uint16)
-	go func(ids idPool, newAlloc chan<- uint16) {
+	go func(ids IdPool, newAlloc chan<- uint16) {
 		newAlloc <- ids.Alloc()
 	}(ids, newAlloc)
 
@@ -31,7 +31,7 @@ func TestIDPool_Alloc(t *testing.T) {
 
 	// now, release a random ID
 	released := uint16(rand.Int31n(65535))
-	go func(ids idPool, released uint16) {
+	go func(ids IdPool, released uint16) {
 		ids.Release(released)
 	}(ids, released)
 
@@ -50,7 +50,7 @@ func TestIDPool_Alloc_withLimit(t *testing.T) {
 	limit := uint32(rand.Int31n(100) + 10)
 	t.Logf("random limit: %d", limit)
 
-	ids := newIDs(limit)
+	ids := NewDynamicIdPool(limit)
 	for i := uint32(0); i < limit; i++ {
 		if want, have := uint16(i), ids.Alloc(); want != have {
 			t.Errorf("expected %d, got %d", want, have)
@@ -60,7 +60,7 @@ func TestIDPool_Alloc_withLimit(t *testing.T) {
 	// test if new id can be allocated
 	// when all ids are already allocated
 	newAlloc := make(chan uint16)
-	go func(ids idPool, newAlloc chan<- uint16) {
+	go func(ids IdPool, newAlloc chan<- uint16) {
 		newAlloc <- ids.Alloc()
 	}(ids, newAlloc)
 
@@ -73,7 +73,7 @@ func TestIDPool_Alloc_withLimit(t *testing.T) {
 
 	// now, release a random ID
 	released := uint16(rand.Int31n(int32(limit)))
-	go func(ids idPool, released uint16) {
+	go func(ids IdPool, released uint16) {
 		ids.Release(released)
 	}(ids, released)
 

--- a/example/php/htdocs/form.php
+++ b/example/php/htdocs/form.php
@@ -1,11 +1,12 @@
 <?php
 
+$submitted = false;
 if (!empty($_POST)) {
   $method = "POST";
-  $submitted = !empty($_POST) ? var_export($_POST, TRUE) : FALSE;
+  $submitted = var_export($_POST, TRUE);
 } else if (!empty($_GET)) {
   $method = "GET";
-  $submitted = !empty($_GET) ? var_export($_GET, TRUE) : FALSE;
+  $submitted = var_export($_GET, TRUE);
 }
 
 $entityBody = file_get_contents('php://input');

--- a/example/php/php_test.go
+++ b/example/php/php_test.go
@@ -132,9 +132,7 @@ func TestNewSimpleHandler(t *testing.T) {
 
 	// start the proxy handler
 	network, address := process.Address()
-	h := php.NewSimpleHandler(
-		path.Join(exmpPath, "htdocs"),
-		network, address)
+	h := php.NewSimpleHandler(path.Join(exmpPath, "htdocs"), network, address)
 
 	// check results
 	w, err := get(h, "/")
@@ -152,6 +150,7 @@ func TestNewSimpleHandler(t *testing.T) {
 		t.Errorf("expected %#v, got %#v", want, have)
 	}
 
+	h = php.NewSimpleHandler(path.Join(exmpPath, "htdocs"), network, address)
 	w, err = get(h, "/index.php")
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
@@ -161,6 +160,7 @@ func TestNewSimpleHandler(t *testing.T) {
 		t.Errorf("expected %#v, got %#v", want, have)
 	}
 
+	h = php.NewSimpleHandler(path.Join(exmpPath, "htdocs"), network, address)
 	w, err = get(h, "/form.php")
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
@@ -171,6 +171,7 @@ func TestNewSimpleHandler(t *testing.T) {
 		t.Errorf("expected to start with %#v, got %#v", formPrefix, have)
 	}
 
+	h = php.NewSimpleHandler(path.Join(exmpPath, "htdocs"), network, address)
 	w, err = get(h, "/form.php?hello=world")
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
@@ -182,6 +183,8 @@ func TestNewSimpleHandler(t *testing.T) {
 
 	form := url.Values{}
 	form.Add("text_input", "hello world")
+
+	h = php.NewSimpleHandler(path.Join(exmpPath, "htdocs"), network, address)
 	w, err = post(h, "/form.php", form.Encode())
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
@@ -199,9 +202,7 @@ func TestNewSimpleHandler__ErrorStream(t *testing.T) {
 
 	// start the proxy handler
 	network, address := process.Address()
-	h := php.NewSimpleHandler(
-		path.Join(exmpPath, "htdocs"),
-		network, address)
+	h := php.NewSimpleHandler(path.Join(exmpPath, "htdocs"), network, address)
 
 	// check results
 	w, err := get(h, "/error.php")
@@ -214,6 +215,7 @@ func TestNewSimpleHandler__ErrorStream(t *testing.T) {
 	}
 
 	// check results
+	h = php.NewSimpleHandler(path.Join(exmpPath, "htdocs"), network, address)
 	w, err = get(h, "/error.php?error_only=1")
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
@@ -234,9 +236,7 @@ func TestNewFileEndpointHandler(t *testing.T) {
 	var err error
 	var resp lzjson.Node
 	network, address := process.Address()
-	h := php.NewFileEndpointHandler(
-		path.Join(exmpPath, "htdocs", "vars.php"),
-		network, address)
+	h := php.NewFileEndpointHandler(path.Join(exmpPath, "htdocs", "vars.php"), network, address)
 
 	// check results for a proper path
 	w, err = get(h, "/")
@@ -256,6 +256,7 @@ func TestNewFileEndpointHandler(t *testing.T) {
 	}
 
 	// check results for a proper path
+	h = php.NewFileEndpointHandler(path.Join(exmpPath, "htdocs", "vars.php"), network, address)
 	w, err = get(h, "/hello/world")
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
@@ -273,6 +274,7 @@ func TestNewFileEndpointHandler(t *testing.T) {
 	}
 
 	// check results for a proper path
+	h = php.NewFileEndpointHandler(path.Join(exmpPath, "htdocs", "vars.php"), network, address)
 	w, err = get(h, "/index.php")
 	if err != nil {
 		t.Errorf("unexpected error %v", err)

--- a/example/php/php_test.go
+++ b/example/php/php_test.go
@@ -125,8 +125,8 @@ func initEnv(t *testing.T, name string, worker int) (exmpPath string, process *p
 
 	return
 }
-func TestNewSimpleHandler(t *testing.T) {
 
+func TestNewSimpleHandler(t *testing.T) {
 	exmpPath, process := initEnv(t, "phpfpm1", 10)
 	defer checkError(t, process.Stop)
 

--- a/id_pool.go
+++ b/id_pool.go
@@ -1,0 +1,100 @@
+package gofast
+
+// IdPool handles allocation and releasing of ids
+type IdPool interface {
+	// Alloc allocates a new id from the pool
+	Alloc() uint16
+
+	// Release releases an id back to the pool
+	Release(id uint16)
+
+	// Close closes the pool
+	Close() error
+}
+
+type staticIdPool struct {
+}
+
+// NewStaticIdPool creates a static id pool
+func NewStaticIdPool() IdPool {
+	return &staticIdPool{}
+}
+
+// Alloc implements IdPool.Alloc
+func (p *staticIdPool) Alloc() uint16 {
+	return 1
+}
+
+// Release implements IdPool.Release
+func (p *staticIdPool) Release(id uint16) {
+	// Noop
+}
+
+// Close implements IdPool.Close
+func (p *staticIdPool) Close() error {
+	return nil
+}
+
+
+type dynamicIdPool struct {
+	IDs chan uint16
+}
+
+func NewDynamicIdPool(limit uint32) IdPool {
+	// Sanitize limit
+	if limit == 0 || limit > 65536 {
+		limit = 65536
+	}
+
+	// pool requestID for the client
+	//
+	// requestID: Identifies the FastCGI request to which the record belongs.
+	// The Web server re-uses FastCGI request IDs; the application
+	// keeps track of the current state of each request ID on a given
+	// transport connection.
+	//
+	// Ref: https://fast-cgi.github.io/spec#33-records
+	ids := make(chan uint16)
+	go func(maxID uint16) {
+		// Recover when IDs channel is closed
+		defer func() {
+			recover()
+		}()
+
+		for i := uint16(0); i < maxID; i++ {
+			ids <- i
+		}
+		ids <- uint16(maxID)
+	}(uint16(limit - 1))
+
+	return &dynamicIdPool{IDs: ids}
+}
+
+// Alloc implements IdPool.Alloc
+func (p *dynamicIdPool) Alloc() uint16 {
+	return <-p.IDs
+}
+
+// Release implements IdPool.Release
+func (p *dynamicIdPool) Release(id uint16) {
+	go func() {
+		// Recover when IDs channel is closed
+		defer func() {
+			recover()
+		}()
+
+		// release the ID back to channel for reuse
+		// use goroutine to prev0, ent blocking ReleaseID
+		p.IDs <- id
+	}()
+}
+
+// Close implements IdPool.Close
+func (p *dynamicIdPool) Close() error {
+	if p.IDs != nil {
+		close(p.IDs)
+		p.IDs = nil
+	}
+
+	return nil
+}

--- a/id_pool_test.go
+++ b/id_pool_test.go
@@ -6,11 +6,70 @@ import (
 	"time"
 )
 
-func TestIDPool_Alloc(t *testing.T) {
+func TestNewStaticIdPool(t *testing.T) {
+	pool := NewStaticIdPool()
+
+	id := pool.Alloc()
+	if id != 1 {
+		t.Errorf("expected: 1, got %d", id)
+	}
+
+	id = pool.Alloc()
+	if id != 1 {
+		t.Errorf("expected: 1, got %d", id)
+	}
+
+	pool.Release(1)
+	pool.Release(2)
+	pool.Release(3)
+
+	err := pool.Close()
+	if err != nil {
+		t.Errorf("could not close pool: %s", err)
+	}
+}
+
+func TestNewDynamicIdPool(t *testing.T) {
+	pool := NewDynamicIdPool(4)
+
+	id := pool.Alloc()
+	if id != 0 {
+		t.Errorf("expected: 0, got %d", id)
+	}
+
+	id = pool.Alloc()
+	if id != 1 {
+		t.Errorf("expected: 1, got %d", id)
+	}
+
+	id = pool.Alloc()
+	if id != 2 {
+		t.Errorf("expected: 2, got %d", id)
+	}
+
+	id = pool.Alloc()
+	if id != 3 {
+		t.Errorf("expected: 3, got %d", id)
+	}
+
+	pool.Release(2)
+
+	id = pool.Alloc()
+	if id != 2 {
+		t.Errorf("expected: 2, got %d", id)
+	}
+
+	err := pool.Close()
+	if err != nil {
+		t.Errorf("could not close pool: %s", err)
+	}
+}
+
+func TestDynamicIdPool_Alloc(t *testing.T) {
 	t.Logf("default limit: %d", 65535)
 	ids := NewDynamicIdPool(0)
-	for i := uint32(0); i <= 65535; i++ {
-		if want, have := uint16(i), ids.Alloc(); want != have {
+	for i := uint16(0); i < 65535; i++ {
+		if want, have := i, ids.Alloc(); want != have {
 			t.Errorf("expected %d, got %d", want, have)
 		}
 	}
@@ -45,14 +104,13 @@ func TestIDPool_Alloc(t *testing.T) {
 	}
 }
 
-func TestIDPool_Alloc_withLimit(t *testing.T) {
-
-	limit := uint32(rand.Int31n(100) + 10)
+func TestDynamicIdPool_Alloc_withLimit(t *testing.T) {
+	limit := uint16(rand.Int31n(100) + 10)
 	t.Logf("random limit: %d", limit)
 
 	ids := NewDynamicIdPool(limit)
-	for i := uint32(0); i < limit; i++ {
-		if want, have := uint16(i), ids.Alloc(); want != have {
+	for i := uint16(0); i < limit; i++ {
+		if want, have := i, ids.Alloc(); want != have {
 			t.Errorf("expected %d, got %d", want, have)
 		}
 	}

--- a/pool_test.go
+++ b/pool_test.go
@@ -68,7 +68,7 @@ func TestPoolClient_Close(t *testing.T) {
 	ch := make(chan *PoolClient)
 	defer close(ch)
 	pc := &PoolClient{
-		Client:       &client{},
+		Client:       &client{ids: NewStaticIdPool()},
 		expires:      time.Now().Add(-time.Millisecond),
 		returnClient: ch,
 	}


### PR DESCRIPTION
After [debugging Skipper's goroutine](https://github.com/yookoala/gofast/issues/48#issuecomment-692604690) leak, @adri came with the idea to completely disable the dynamic id pool for Skipper.

I think it makes sense, as Skipper doesn't need this pool because it creates and destroys clients for every request.

Therefore, this PR introduces an IdPool interface with 2 implementations: DynamicIdPool (current implementation) and a new StaticIdPool that always allocates the same number.

This could be used by projects that don't need to have an always running goroutine that generates ids (Skipper for example).

## Todo

- [x] Properly close channel #51 
- [x] Add new `ClientFactory` that creates a client with static id pool

@yookoala WDYT about this? Would this make sense? 