### PR TITLE
travis: prevent duplicated trigger in pull request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ env:
   - TEST_PHPFPM_PATH=/usr/sbin/php-fpm7.4
   - GO111MODULE=on
 
+if:
+  (type = pull_request AND head_repo != repo) OR
+  (type = push)
+
 before_script:
   # for python3 tests
   - python3 -m venv myvenv


### PR DESCRIPTION
* If the trigger is a pull request, only run if the head_repo is
  not the same as repo.

  Reference: https://docs.travis-ci.com/user/conditions-v1