### PR TITLE
possible fix of invalid memory address dereference (#74 and #48)

### DIFF
--- a/client.go
+++ b/client.go
@@ -207,10 +207,10 @@ func (c *client) readResponse(ctx context.Context, resp *ResponsePipe, req *Requ
 	done := make(chan int)
 
 	// readloop in goroutine
-	go func() {
+	go func(rwc io.ReadWriteCloser) {
 	readLoop:
 		for {
-			if err := rec.read(c.conn.rwc); err != nil {
+			if err := rec.read(rwc); err != nil {
 				break
 			}
 
@@ -228,7 +228,7 @@ func (c *client) readResponse(ctx context.Context, resp *ResponsePipe, req *Requ
 			}
 		}
 		close(done)
-	}()
+	}(c.conn.rwc)
 
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
I was experiencing occasional segmentation violation crashes, mostly during load tests with wrk. It happened only sometimes, so it's hard to reproduce it with 100% success, but I think I finally get rid off all crashes with this simple change in code.