### PR TITLE
Extend tested go version coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        #go: [' 1.7', '1.8', '1.9', '1.10', '1.11', '1.12', '1.13', '1.14', '1.15' ]
-        go: ['1.11', '1.12', '1.13', '1.14', '1.15', '1.16']
+        go: ['1.11', '1.12', '1.13', '1.14', '1.15', '1.16', '1.17', '1.18']
     env:
       # For test to correctly locate the OS's php-fpm
       TEST_PHPFPM_PATH: /usr/sbin/php-fpm7.4


### PR DESCRIPTION
* Test against go 1.17 and 1.18.