### PR TITLE
Extend tested go version coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,11 @@ jobs:
       GO111MODULE: on
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Tools for Tests
         run: sudo apt-get install -y php-fpm python3 python3-venv
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '14'
       - name: Setup Node modules
@@ -45,7 +45,7 @@ jobs:
           yarn install
           cd ../..
       - name: Setup Python3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
       - name: Setup Python3 modules
@@ -53,7 +53,7 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install -r example/python3/requirements.txt
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
       - name: Setup Go modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,18 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: ['1.11', '1.12', '1.13', '1.14', '1.15', '1.16', '1.17', '1.18']
+        go:
+          - '1.11'
+          - '1.12'
+          - '1.13'
+          - '1.14'
+          - '1.15'
+          - '1.16'
+          - '1.17'
+          - '1.18'
+          - '1.19'
+          - '1.20'
+          - '1.21'
     env:
       # For test to correctly locate the OS's php-fpm
       TEST_PHPFPM_PATH: /usr/sbin/php-fpm7.4

--- a/host.go
+++ b/host.go
@@ -71,7 +71,7 @@ func (h *defaultHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	errBuffer := new(bytes.Buffer)
 	if err = resp.WriteTo(w, errBuffer); err != nil {
-		log.Printf("gofast: error writing error buffer to response: %s", err)
+		log.Printf("gofast: problem writing error buffer to response - %s", err)
 	}
 
 	if errBuffer.Len() > 0 {


### PR DESCRIPTION
* Test against go 1.19, 1.20 and 1.21.