### PR TITLE
Read both Content-Length header and req.ContentLength

### DIFF
--- a/session.go
+++ b/session.go
@@ -120,7 +120,11 @@ func BasicParamsMap(inner SessionHandler) SessionHandler {
 
 		// the basic information here
 		req.Params["CONTENT_TYPE"] = r.Header.Get("Content-Type")
-		req.Params["CONTENT_LENGTH"] = r.Header.Get("Content-Length")
+		cl := r.Header.Get("Content-Length")
+		if cl == "" {
+			cl = strconv.FormatInt(r.ContentLength, 10)
+		}
+		req.Params["CONTENT_LENGTH"] = cl
 		req.Params["GATEWAY_INTERFACE"] = "CGI/1.1"
 		req.Params["REMOTE_ADDR"] = remoteAddr
 		req.Params["REMOTE_PORT"] = remotePort


### PR DESCRIPTION
This should fix an issue where if you put a fcgi application behind fcgi listener, the content length is lost.

Eg (HTTP req) -> WebServer -> fastcgi -> (Go App with fcgi + http + gofast) -> PHP

All requests lose their body.  