### PR TITLE
Update test to use node20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Python3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.12'
       - name: Setup Python3 modules
         run: |
           python3 -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,16 +36,16 @@ jobs:
       - name: Install Tools for Tests
         run: sudo apt-get install -y php-fpm python3 python3-venv
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 20
       - name: Setup Node modules
         run: |
           cd ./example/nodejs
           npm install
           cd ../..
       - name: Setup Python3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - name: Setup Python3 modules
@@ -53,7 +53,7 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install -r example/python3/requirements.txt
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
       - name: Setup Go modules


### PR DESCRIPTION
* Follow instruction here to update the node version to run test:
  https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/